### PR TITLE
use std::isnan

### DIFF
--- a/src/ITKFilters/include/MultiComponentMutualInfoImageMetric.txx
+++ b/src/ITKFilters/include/MultiComponentMutualInfoImageMetric.txx
@@ -523,7 +523,7 @@ MutualInformationPreprocessingFilter<TInputImage, TOutputImage>
       for(int p = 0; p < line_length; p++, line+=ncomp)
         {
         InputComponentType v = *line;
-        if(!isnan(v))
+        if(!std::isnan(v))
           {
           heap_lower_push(td.heap_lower, heap_size_lower, v);
           heap_upper_push(td.heap_upper, heap_size_upper, v);

--- a/src/ITKFilters/include/MultiComponentNCCImageMetric.txx
+++ b/src/ITKFilters/include/MultiComponentNCCImageMetric.txx
@@ -179,9 +179,9 @@ MultiImageNCCPrecomputeFilter<TMetricTraits,TOutputImage>
             InputComponentType x_fix = iter.GetFixedLine()[k];
 
             // Check for NaN, which indicates that the pixel should not contribute to the metric
-            if(isnan(x_mov) || isnan(x_fix))
+            if(std::isnan(x_mov) || std::isnan(x_fix))
               {
-              if(!need_affine || isnan(x_fix))
+              if(!need_affine || std::isnan(x_fix))
                 {
                 // When not doing affine, or it's the fixed image that's nan, zero out the component
                 for(int j = 0; j < n_out_comp_per_input_comp; j++)

--- a/src/MultiImageRegistrationHelper.cxx
+++ b/src/MultiImageRegistrationHelper.cxx
@@ -251,8 +251,8 @@ MultiImageOpticalFlowHelper<TFloat, VDim>
         }
       else
         {
-        nans_fixed = isnan(LDDMMType::img_voxel_sum(fltExtractFixed->GetOutput()));
-        nans_moving = isnan(LDDMMType::img_voxel_sum(fltExtractMoving->GetOutput()));
+        nans_fixed = std::isnan(LDDMMType::img_voxel_sum(fltExtractFixed->GetOutput()));
+        nans_moving = std::isnan(LDDMMType::img_voxel_sum(fltExtractMoving->GetOutput()));
         }
 
       // Report number of NaNs in fixed and moving images

--- a/src/lddmm_data.cxx
+++ b/src/lddmm_data.cxx
@@ -1758,7 +1758,7 @@ public:
   typedef typename TImage::PixelType PixelType;
   PixelType operator() (const PixelType &x)
   {
-    return isnan(x) ? 1 : 0;
+    return std::isnan(x) ? 1 : 0;
   }
 };
 
@@ -1771,7 +1771,7 @@ public:
   typedef typename TImage::PixelType PixelType;
   PixelType operator() (const PixelType &x)
   {
-    return isnan(x) ? 0 : x;
+    return std::isnan(x) ? 0 : x;
   }
 };
 


### PR DESCRIPTION
scoping `isnan` to use the stdlib version fixes #23 

Is there a better `isnon` to use :shrug: 