### PR TITLE
Fixed build issue related to function renaming

### DIFF
--- a/src/lddmm_main.cxx
+++ b/src/lddmm_main.cxx
@@ -220,7 +220,7 @@ int run_test(int argc, char *argv[])
 
     // Read the random variation
     typename LDDMM::VelocityField h;
-    LDDMM::alloc_vf(h, p.nt, p.fix);
+    LDDMM::new_vf(h, p.nt, p.fix);
     LDDMM::vfield_read(nt, argv[5], h);
 
     // gateaux_analytic = lddmm_vector_field_dot_product(dedvx, dedvy, varx, vary, p);


### PR DESCRIPTION
Breaking change: Commit 134ed47 (2019-04-11, "Incorporating MRI into stackgreedy...") renamed the static method LDDMMData::alloc_vf → new_vf in [lddmm_data.h], but the sole caller at [lddmm_main.cxx:223] was missed.

Why it didn't fail until now: The body of run_test() is inside if(argc >= 4 && !strcmp(argv[3], "test")) and the call is inside a template function — so the template was never instantiated unless code using it was actually referenced. Something in the recent build environment (likely stricter template instantiation from the newer g++/C++17 setup) is now forcing it. The rename has been latent for roughly 7 years.

Fix: LDDMM::alloc_vf(h, p.nt, p.fix); → LDDMM::new_vf(h, p.nt, p.fix);. The lddmm target now builds cleanly.