### PR TITLE
Build linux/aarch64 wheels by compiling VTK from source

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest,macos-13,macos-14,windows-2022]
+        os: [ubuntu-latest,ubuntu-22.04-arm,macos-13,macos-14,windows-2022]
         # os: [ubuntu-22.04,ubuntu-22.04-arm,macos-13,macos-13-xlarge,macos-14,macos-14-xlarge,windows-2019,windows-2022]
 
     steps:
@@ -42,7 +42,7 @@ jobs:
       - name: Compile and Build wheels
         uses: pypa/cibuildwheel@v2.20.0
         env:
-            CIBW_ARCHS_LINUX: x86_64
+            CIBW_ARCHS_LINUX: auto
             CIBW_ARCHS_WINDOWS: AMD64
             CIBW_SKIP: "*musllinux*"
             CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/prebuild.sh
+++ b/.github/workflows/prebuild.sh
@@ -15,7 +15,15 @@ ls -lh ..
 # Download and build VTK
 LIB_LOCATION=build
 if [[ $1 =~ ubuntu-.* ]]; then
-  VTK_BINARY=vtk-wheel-sdk-9.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.tar.xz
+  # Kitware publishes the VTK wheel-SDK for x86_64 only — there is no linux aarch64
+  # build at any released version — so on aarch64 we build VTK from source instead.
+  # Note this branch previously matched on OS alone, so an arm runner would have
+  # downloaded the x86_64 SDK.
+  if [[ "$(uname -m)" == "aarch64" || "$(uname -m)" == "arm64" ]]; then
+    VTK_FROM_SOURCE=1
+  else
+    VTK_BINARY=vtk-wheel-sdk-9.3.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.tar.xz
+  fi
   DYLD_SUFFIX=so
   MAKEFLAGS="-- -j 8"
 elif [[ $1 == macos-13 ]]; then
@@ -46,11 +54,58 @@ cmake \
 
 cmake --build eigen/build --target install $MAKEFLAGS $CMAKE_RELEASE_COMMAND
 
-# Install VTK from binary wheels provided by Kitware
 mkdir -p install/vtk install/vtk/shared
-curl -L https://www.vtk.org/files/release/9.3/${VTK_BINARY} -o ./install/vtk/vtk-wheel-sdk.tar.xz
-tar -xJvf ./install/vtk/vtk-wheel-sdk.tar.xz --strip-components 1 -C $PWD/install/vtk
-ln $(find $PWD/install/vtk/${LIB_LOCATION} -name "*.${DYLD_SUFFIX}") install/vtk/shared
+if [[ -n "${VTK_FROM_SOURCE:-}" ]]; then
+  # Build only the modules greedy's CMakeLists actually requires. Refusing the
+  # Rendering/Qt/Views/Web groups is what keeps this cheap: the trimmed build takes
+  # a couple of minutes, where a full VTK build would dominate the job.
+  git clone --depth 1 -b v9.3.1 https://github.com/Kitware/VTK.git VTK
+  cmake \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_SHARED_LIBS=OFF \
+      -DBUILD_TESTING=OFF \
+      -DVTK_BUILD_TESTING=OFF \
+      -DVTK_BUILD_EXAMPLES=OFF \
+      -DVTK_BUILD_DOCUMENTATION=OFF \
+      -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+      -DVTK_GROUP_ENABLE_Rendering=DONT_WANT \
+      -DVTK_GROUP_ENABLE_Qt=DONT_WANT \
+      -DVTK_GROUP_ENABLE_Views=DONT_WANT \
+      -DVTK_GROUP_ENABLE_Web=DONT_WANT \
+      -DVTK_GROUP_ENABLE_Imaging=DONT_WANT \
+      -DVTK_GROUP_ENABLE_MPI=DONT_WANT \
+      -DVTK_GROUP_ENABLE_StandAlone=DONT_WANT \
+      -DVTK_MODULE_ENABLE_VTK_CommonCore=YES \
+      -DVTK_MODULE_ENABLE_VTK_IOCore=YES \
+      -DVTK_MODULE_ENABLE_VTK_IOLegacy=YES \
+      -DVTK_MODULE_ENABLE_VTK_IOPLY=YES \
+      -DVTK_MODULE_ENABLE_VTK_IOGeometry=YES \
+      -DVTK_MODULE_ENABLE_VTK_IOImage=YES \
+      -DVTK_MODULE_ENABLE_VTK_IOXML=YES \
+      -DVTK_MODULE_ENABLE_VTK_FiltersCore=YES \
+      -DVTK_MODULE_ENABLE_VTK_FiltersGeneral=YES \
+      -DVTK_MODULE_ENABLE_VTK_FiltersModeling=YES \
+      -DCMAKE_INSTALL_PREFIX=$PWD/install/vtk \
+      -B VTK/build \
+      VTK
+  cmake --build VTK/build --target install $MAKEFLAGS $CMAKE_RELEASE_COMMAND
+
+  # Expose the config at the same path the wheel-SDK provides, so CIBW_ENVIRONMENT's
+  # VTK_DIR needs no per-architecture variant. VTK's exported targets resolve library
+  # paths RELATIVE to the config file — CMake walks three levels up from
+  # vtk-9.3.1.data/headers/cmake and expects the prefix there — which is why VTK is
+  # installed into install/vtk above rather than install/. Installing elsewhere makes
+  # configure fail with "imported target references a file that does not exist".
+  mkdir -p install/vtk/vtk-9.3.1.data/headers
+  ln -sfn "$(dirname "$(find $PWD/install/vtk -name 'vtk-config.cmake' | head -1)")" \
+          install/vtk/vtk-9.3.1.data/headers/cmake
+  # Static build: nothing for auditwheel to bundle, so install/vtk/shared stays empty.
+else
+  # Install VTK from binary wheels provided by Kitware
+  curl -L https://www.vtk.org/files/release/9.3/${VTK_BINARY} -o ./install/vtk/vtk-wheel-sdk.tar.xz
+  tar -xJvf ./install/vtk/vtk-wheel-sdk.tar.xz --strip-components 1 -C $PWD/install/vtk
+  ln $(find $PWD/install/vtk/${LIB_LOCATION} -name "*.${DYLD_SUFFIX}") install/vtk/shared
+fi
 
 # Link the shared libraries needed for delocate into a simple directory
 


### PR DESCRIPTION
Hi, thank you very much for providing greedy. We are actively using it in [LST-AI](https://github.com/CompImg/LST-AI) and really love the speed and performance.

Right now, we are actively trying to port our stack to non x86 architectures, most recently using the DGX Spark architecture (ARM-based CPU).

## Why?

`picsl-greedy` publishes no linux aarch64 wheel. The blocker isn't greedy; it builds fine on arm64, as the macOS arm64 wheels demonstrate. It's Kitware's VTK wheel-SDK that `prebuild.sh` downloads, which exists for x86_64 only:

| version | x86_64 | aarch64 |
|---------------|------------------|---------|
| 9.3.1 | 200 | 404 |
| 9.4.1 | 200 | 404 |
| 9.5.0 / 9.6.0 | no SDK published | n/a |

Everything else `prebuild.sh` needs (Eigen, ITK) is already built from source and is architecture-agnostic. Only VTK has to change.

## What

On aarch64, build VTK from source instead of downloading the SDK, enabling only the ten modules `CMakeLists.txt` requires and refusing the Rendering/Qt/Views/Web/Imaging/MPI groups. That's what keeps it cheap, the whole prebuild takes ~6 mins in `manylinux2014_aarch64`.

`compile.yml` enables the `ubuntu-22.04-arm` runner already present in your commented-out matrix, and sets `CIBW_ARCHS_LINUX: auto` so each linux runner builds natively.

## Two things you may want to know regardless of this PR

The `ubuntu-*` branch matches on OS alone, so enabling an arm runner without this change would have silently downloaded the x86_64 SDK. It now tests `uname -m`.

VTK's exported targets resolve library paths relative to the config file. CMake walks three levels up from `vtk-9.3.1.data/headers/cmake`, so VTK is installed into `install/vtk` for that arithmetic to land correctly, and the config is symlinked to the SDK's path. This means `CIBW_ENVIRONMENT`'s `VTK_DIR` needs no per-arch variant and every other platform is byte-identical.

## Verification

Built on a DGX Spark (GB10, aarch64). The wheel imports and registers. On five subjects of the Mendeley MS dataset, an affine registration recovering a known 6 degree rotation plus 5 voxel translation raised lesion-mask Dice from a range of 0.15 to 0.40 (before registration) to a mean of 0.989 (after).

## Note re #57

#57 bumps cibuildwheel two lines from one of our edits, so a small conflict is likely. More substantively: if that bump moves the default manylinux image to `manylinux_2_28`, ITK 5.2.1 will fail to build, `'uint8_t' was not declared in this scope` in `itkMathematicalMorphologyEnums.h`, because GCC 13 no longer includes `<cstdint>` transitively. We hit this directly. `manylinux2014` (GCC 10.2.1) is unaffected, so this PR doesn't need a workaround, but it will surface whenever the image moves.

## AI Disclosure

We used claude code in the development process.